### PR TITLE
Add context option

### DIFF
--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -41,6 +41,7 @@ export const months = [
 
 const defaultOptions = {
 	el: null,
+	context: document,
 	dateFormat: 'DD-MMM-YYYY',
 	bodyType: 'modal', // ['modal', 'inline', 'permanent']
 	autoClose: false,

--- a/src/js/instance.js
+++ b/src/js/instance.js
@@ -7,7 +7,7 @@ import { getActiveMonths, getLimitDates, getViewLayers } from './handlers';
 export default function createInstance(datepicker, calendarNodes, instanceOptions) {
 	instanceOptions.allowedYears.sort((first, next) => first - next);
 	const linkedElement =
-		instanceOptions.el !== null ? document.querySelector(instanceOptions.el) : null;
+		instanceOptions.el !== null ? instanceOptions.context.querySelector(instanceOptions.el) : null;
 	const activeMonths = getActiveMonths(instanceOptions);
 	const { prevLimitDate, nextLimitDate } = getLimitDates(instanceOptions);
 	const viewLayers = getViewLayers(instanceOptions);
@@ -17,6 +17,7 @@ export default function createInstance(datepicker, calendarNodes, instanceOption
 		_id: uniqueId(),
 		datepicker: datepicker,
 		el: instanceOptions.el,
+		context: instanceOptions.context,
 		linkedElement: linkedElement,
 		pickedDate: instanceOptions.selectedDate,
 		viewLayers: viewLayers,

--- a/src/js/validators.js
+++ b/src/js/validators.js
@@ -74,6 +74,7 @@ export const eventColorTypeSchema = {
 
 const optionsSchema = {
 	el: (value) => /^[#][-\w]+$/.test(value),
+	context: (value) => value.nodeType == Node.ELEMENT_NODE,
 	dateFormat: (value) => dateFormatValidator(value).isValid(),
 	bodyType: (value) => {
 		const types = ['modal', 'inline', 'permanent'];


### PR DESCRIPTION
Add a context option so the `el` can be queried from different containers. Useful for performance but also when working with other frame contexts such as iframes and shadow dom.