### PR TITLE
Correct support for shadow dom + accessibility enhancements

### DIFF
--- a/sandbox/index.js
+++ b/sandbox/index.js
@@ -157,3 +157,33 @@ setYearInput.onchange = (e) => {
 setYearBtn.onclick = () => {
 	setYearValue !== null && secundDatePicker.setYear(setYearValue);
 };
+
+// Test Shadow Dom usage
+document.addEventListener("DOMContentLoaded", setupShadowDOM);
+
+function setupShadowDOM() {
+	const el = document.querySelector('#shadow-dom');
+	if (document.head.attachShadow) {
+		el.attachShadow({mode: 'open'});
+		const shadowRoot = el.shadowRoot;
+
+		// Add input to shadow dom
+		const el2 = document.createElement('input');
+		el2.id = 'shadow-picker-el';
+		shadowRoot.append(el2);
+
+		// Add styles to shadow dom
+		const styleEl = document.querySelector('head link').cloneNode();
+		shadowRoot.append(styleEl);
+
+		setupShadowPicker(shadowRoot);
+	}
+}
+
+function setupShadowPicker(shadowRoot) {
+	window.shadowDatePicker = MCDatepicker.create({
+		el: '#shadow-picker-el',
+		context: shadowRoot,
+		bodyType: 'inline',
+	});
+}

--- a/sandbox/template.html
+++ b/sandbox/template.html
@@ -74,6 +74,7 @@
 				</div>
 			</div>
 		</div>
+		<div id="shadow-dom"></div>
 	</main>
 </body>
 

--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -41,7 +41,7 @@ export const months = [
 
 const defaultOptions = {
 	el: null,
-	context: document,
+	context: document.body,
 	dateFormat: 'DD-MMM-YYYY',
 	bodyType: 'modal', // ['modal', 'inline', 'permanent']
 	autoClose: false,

--- a/src/js/emiters.js
+++ b/src/js/emiters.js
@@ -9,7 +9,8 @@ import {
 	CHANGE_YEAR,
 	DATE_PICK,
 	PREVIEW_PICK,
-	SET_DATE
+	SET_DATE,
+	CANCEL
 } from './events';
 
 export const dispatchCalendarShow = (elem, instance) => {
@@ -92,4 +93,8 @@ export const dispatchSetDate = (elem, detail = { instance: null, date: null }) =
 			detail
 		})
 	);
+};
+
+export const dispatchCancel = (elem) => {
+	elem.dispatchEvent(new CustomEvent(CANCEL, { bubbles: true }));
 };

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -9,3 +9,4 @@ export const PREVIEW_PICK = 'preview-pick';
 export const CHANGE_MONTH = 'month-change';
 export const CHANGE_YEAR = 'year-change';
 export const SET_DATE = 'set-date';
+export const CANCEL = 'cancel-calendar';

--- a/src/js/handlers.js
+++ b/src/js/handlers.js
@@ -14,10 +14,12 @@ export const getDOMNodes = (calendar) => {
 	const nodes = {
 		calendar,
 		calendarDisplay: calendar.querySelector('.mc-display'),
+		calendarPicker: calendar.querySelector('.mc-picker'),
 		displayDay: calendar.querySelector('.mc-display__day'),
 		displayDate: calendar.querySelector('.mc-display__date'),
 		displayMonth: calendar.querySelector('.mc-display__month'),
 		displayYear: calendar.querySelector('.mc-display__year'),
+		accessibilityMonthYear: calendar.querySelector('#mc-picker__month-year'),
 		calendarHeader: calendar.querySelector('.mc-picker__header'),
 		currentMonthSelect: calendar.querySelector('#mc-current--month'),
 		currentYearSelect: calendar.querySelector('#mc-current--year'),
@@ -243,6 +245,7 @@ export const updateWeekdays = (calendarNodes, options) => {
 	weekdays.forEach((wDay, index) => {
 		const nextElement = (firstWeekday + index) % customWeekDays.length;
 		wDay.innerText = customWeekDays[nextElement].substr(0, 2);
+		wDay.setAttribute('aria-label', customWeekDays[nextElement])
 	});
 };
 
@@ -279,11 +282,13 @@ export const updateCalendarTable = (calendarNodes, instance) => {
 		cell.innerText = datesArray[index].dateNumb;
 		cell.classList = datesArray[index].classList;
 		cell.setAttribute('data-val-date', datesArray[index].date);
+		cell.setAttribute('tabindex', datesArray[index].tabindex);
+		cell.setAttribute('aria-label', datesArray[index].ariaLabel);
 	});
 };
 
 export const updateCalendarHeader = (calendarNodes, instance) => {
-	const { currentMonthSelect, currentYearSelect, calendarHeader } = calendarNodes;
+	const { currentMonthSelect, currentYearSelect, calendarHeader, accessibilityMonthYear } = calendarNodes;
 	const { store, options } = instance;
 	const { customMonths } = options;
 	const { target, month, year } = store.header;
@@ -301,6 +306,7 @@ export const updateCalendarHeader = (calendarNodes, instance) => {
 	}
 	currentMonthSelect.innerHTML = `<span>${customMonths[month]}</span>`;
 	currentYearSelect.innerHTML = `<span>${year}</span>`;
+	accessibilityMonthYear.innerText = `${customMonths[month]} ${year}`;
 };
 
 export const updateMonthYearPreview = (calendarNodes, instance) => {

--- a/src/js/mc-calendar.js
+++ b/src/js/mc-calendar.js
@@ -10,9 +10,9 @@ const MCDatepicker = (() => {
 	let datepickers = [];
 	let calendarNodes = null;
 
-	const initCalendar = () => {
+	const initCalendar = (instanceOptions) => {
 		if (calendarNodes) return;
-		calendarNodes = writeTemplate();
+		calendarNodes = writeTemplate(instanceOptions);
 	};
 
 	const open = (uid) => {
@@ -29,10 +29,10 @@ const MCDatepicker = (() => {
 	};
 
 	const create = (options = {}) => {
-		// initiate the calendar instance once
-		initCalendar();
 		// validate options and merge them with de default Options
 		const instanceOptions = validateOptions(options, defaultOptions);
+		// initiate the calendar instance once
+		initCalendar(instanceOptions);
 		// create instance
 		const instance = createInstance(MCDatepicker, calendarNodes, instanceOptions);
 		// push fresh created instance to instances array

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -47,11 +47,12 @@ const getCalendarArray = (options, firstMonthDate) => {
 };
 
 export const renderMonthPreview = (calendarNodes, instance) => {
-	const { previewCells } = calendarNodes;
+	const { previewCells, currentMonthSelect } = calendarNodes;
 	const { store, prevLimitDate, nextLimitDate, options } = instance;
 	const { customMonths } = options;
 	const currentMonth = customMonths[store.preview.month];
 	const selectedYear = store.preview.year;
+	currentMonthSelect.setAttribute('aria-expanded', true);
 	customMonths.map((month, index) => {
 		let monthClasslist = ['mc-month-year__cell'];
 		const firstMonthDate = new Date(Number(selectedYear), index);
@@ -60,7 +61,11 @@ export const renderMonthPreview = (calendarNodes, instance) => {
 			prevLimitDate && valueOfDate(lastMonthDate) < valueOfDate(prevLimitDate);
 		const moreThanMaxDate =
 			nextLimitDate && valueOfDate(firstMonthDate) > valueOfDate(nextLimitDate);
-		if (month === currentMonth) monthClasslist.push('mc-month-year__cell--picked');
+		let ariaLabel = month;
+		if (month === currentMonth) {
+			monthClasslist.push('mc-month-year__cell--picked');
+			ariaLabel = `Current Month: ${ariaLabel}`;
+		}
 		if (
 			lessThanMinDate ||
 			moreThanMaxDate ||
@@ -68,19 +73,24 @@ export const renderMonthPreview = (calendarNodes, instance) => {
 			!isActiveYear(options, Number(selectedYear))
 		) {
 			monthClasslist.push('mc-month-year__cell--inactive');
+			previewCells[index].setAttribute('tabindex', -1);
+		} else {
+			previewCells[index].setAttribute('tabindex', 0);
 		}
 
 		previewCells[index].classList = monthClasslist.join(' ');
 		previewCells[index].innerHTML = `<span>${month.substr(0, 3)}</span>`;
+		previewCells[index].setAttribute('aria-label', month);
 	});
 };
 
 export const renderYearPreview = (calendarNodes, instance, year) => {
-	const { previewCells } = calendarNodes;
+	const { previewCells, currentYearSelect } = calendarNodes;
 	const { store, prevLimitDate, nextLimitDate, options } = instance;
 	const minYear = prevLimitDate && prevLimitDate.getFullYear();
 	const maxYear = nextLimitDate && nextLimitDate.getFullYear();
 	const currentYear = store.preview.year;
+	currentYearSelect.setAttribute('aria-expanded', true);
 	previewCells.forEach((cell, index) => {
 		let yearClasslist = ['mc-month-year__cell'];
 		let customYear = year + index;
@@ -89,6 +99,9 @@ export const renderYearPreview = (calendarNodes, instance, year) => {
 		if (customYear === currentYear) yearClasslist.push('mc-month-year__cell--picked');
 		if (lessThanMinYear || moreThanMaxYear || !isActiveYear(options, customYear)) {
 			yearClasslist.push('mc-month-year__cell--inactive');
+			previewCells[index].setAttribute('tabindex', -1);
+		} else {
+			previewCells[index].setAttribute('tabindex', 0);
 		}
 		cell.classList = yearClasslist.join(' ');
 		cell.innerHTML = `<span>${customYear}</span>`;
@@ -105,6 +118,7 @@ export const renderCalendar = (instance, date) => {
 	//  create date custom object
 	const renderDay = (dayObject) => {
 		let classArray = ['mc-date'];
+		dayObject.ariaLabel = dayObject.date.toDateString();
 		// check the cases when the date is not active
 		if (
 			!isInActiveMonth(activeMonth, dayObject) ||
@@ -116,14 +130,25 @@ export const renderCalendar = (instance, date) => {
 			isDisabledDate(options, dayObject)
 		) {
 			classArray.push('mc-date--inactive');
+			dayObject.tabindex = -1;
 		} else {
 			classArray.push('mc-date--active');
+			dayObject.tabindex = 0;
 		}
-		if (isPicked(pickedDate, dayObject)) classArray.push('mc-date--picked');
+		if (isPicked(pickedDate, dayObject)){
+			classArray.push('mc-date--picked');
+			dayObject.ariaLabel = `Picked: ${dayObject.ariaLabel}`;
+		}
 
-		if (isMarked(instance, dayObject)) classArray.push('mc-date--marked');
+		if (isMarked(instance, dayObject)) {
+			classArray.push('mc-date--marked');
+			dayObject.ariaLabel = `Marked: ${dayObject.ariaLabel}`;
+		}
 
-		if (isToday(dayObject)) classArray.push('mc-date--today');
+		if (isToday(dayObject)) {
+			classArray.push('mc-date--today');
+			dayObject.ariaLabel = `Today: ${dayObject.ariaLabel}`;
+		}
 
 		dayObject.classList = classArray.join(' ');
 
@@ -131,7 +156,6 @@ export const renderCalendar = (instance, date) => {
 	};
 
 	const calendarArray = getCalendarArray(options, firstMonthDate);
-
 	return calendarArray.map((day) => renderDay(day));
 };
 

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -135,7 +135,7 @@ export const renderCalendar = (instance, date) => {
 	return calendarArray.map((day) => renderDay(day));
 };
 
-export function writeTemplate() {
+export function writeTemplate(instanceOptions) {
 	// create a new div tag
 	const calendarDiv = document.createElement('div');
 	// set the classList of the created div
@@ -145,7 +145,7 @@ export function writeTemplate() {
 	// write the template to the div content
 	calendarDiv.innerHTML = template;
 	// add the new div to the document
-	document.body.appendChild(calendarDiv);
+	instanceOptions.context.appendChild(calendarDiv);
 	// get calendar Nodes
 	const calendarNodes = getDOMNodes(calendarDiv);
 	// apply listeners to calendar

--- a/src/js/template.js
+++ b/src/js/template.js
@@ -20,15 +20,15 @@ export default `<div class="mc-display" data-target="calendar">
 <div class="mc-picker">
 <div class="mc-picker__header mc-select mc-container" data-target="calendar">
 <div class="mc-select__month">
-<button id="mc-picker__month--prev" class="mc-select__nav mc-select__nav--prev">
+<button id="mc-picker__month--prev" class="mc-select__nav mc-select__nav--prev" tabindex="0" aria-label="Previous Month">
 <svg class="icon-angle icon-angle--left" viewBox="0 0 256 512" width='10px' height='100%'>
 <path fill="currentColor" d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z" />
 </svg>
 </button>
-<div id="mc-current--month" class="mc-select__data mc-select__data--month">
+<div id="mc-current--month" class="mc-select__data mc-select__data--month" tabindex="0" aria-label="Click to select month" aria-haspopup="true" aria-expanded="false" aria-controls="mc-month-year__preview">
 <span>January</span>
 </div>
-<button id="mc-picker__month--next" class="mc-select__nav mc-select__nav--next">
+<button id="mc-picker__month--next" class="mc-select__nav mc-select__nav--next" tabindex="0" aria-label="Next Month">
 <svg class="icon-angle icon-angle--right" viewBox="0 0 256 512" width='10px' height='100%'>
 <path fill="currentColor" d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z" />
 </svg>
@@ -40,7 +40,7 @@ export default `<div class="mc-display" data-target="calendar">
 <path fill="currentColor" d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z" />
 </svg>
 </button>
-<div id="mc-current--year" class="mc-select__data mc-select__data--year">
+<div id="mc-current--year" class="mc-select__data mc-select__data--year" tabindex="0" aria-label="Click to select year" aria-haspopup="true" aria-expanded="false" aria-controls="mc-month-year__preview">
 <span>1970</span>
 </div>
 <button id="mc-picker__year--next" class="mc-select__nav mc-select__nav--next">
@@ -49,9 +49,10 @@ export default `<div class="mc-display" data-target="calendar">
 </svg>
 </button>
 </div>
+<div id="mc-picker__month-year" class="mc-picker-vhidden" aria-live="polite" aria-atomic="true">January 1970</div>
 </div>
 <div class="mc-picker__body">
-<table class="mc-table mc-container">
+<table class="mc-table mc-container" aria-labelledby="mc-picker__month-year">
 <thead class="mc-table__header">
 <tr>
 <th class="mc-table__weekday">S</th>
@@ -120,7 +121,7 @@ export default `<div class="mc-display" data-target="calendar">
 </tr>
 </tbody>
 </table>
-<div class="mc-month-year__preview" data-target=null>
+<div id="mc-month-year__preview" class="mc-month-year__preview" data-target=null role="menu">
 <div class="mc-month-year__cell"></div>
 <div class="mc-month-year__cell"></div>
 <div class="mc-month-year__cell"></div>
@@ -137,11 +138,11 @@ export default `<div class="mc-display" data-target="calendar">
 </div>
 <div class="mc-picker__footer mc-container">
 <div class="mc-footer__section mc-footer__section--primary">
-<button id="mc-btn__clear" class="mc-btn mc-btn--danger">Clear</button>
+<button id="mc-btn__clear" class="mc-btn mc-btn--danger" tabindex="0">Clear</button>
 </div>
 <div class="mc-footer__section mc-footer__section--secondary">
-<button id="mc-btn__cancel" class="mc-btn mc-btn--success">CANCEL</button>
-<button id="mc-btn__ok" class="mc-btn mc-btn--success">OK</button>
+<button id="mc-btn__cancel" class="mc-btn mc-btn--success" tabindex="0">CANCEL</button>
+<button id="mc-btn__ok" class="mc-btn mc-btn--success" tabindex="0">OK</button>
 </div>
 </div>
 </div>`;

--- a/src/js/validators.js
+++ b/src/js/validators.js
@@ -74,7 +74,7 @@ export const eventColorTypeSchema = {
 
 const optionsSchema = {
 	el: (value) => /^[#][-\w]+$/.test(value),
-	context: (value) => value.nodeType == Node.ELEMENT_NODE,
+	context: (value) => value.nodeType == Node.ELEMENT_NODE || value.nodeType == Node.DOCUMENT_FRAGMENT_NODE,
 	dateFormat: (value) => dateFormatValidator(value).isValid(),
 	bodyType: (value) => {
 		const types = ['modal', 'inline', 'permanent'];

--- a/src/scss/_components.buttons.scss
+++ b/src/scss/_components.buttons.scss
@@ -23,7 +23,6 @@
 
 	&:focus {
 		-webkit-tap-highlight-color: transparent;
-		outline: none;
 		-ms-touch-action: manipulation;
 		touch-action: manipulation;
 	}

--- a/src/scss/_components.selector.scss
+++ b/src/scss/_components.selector.scss
@@ -31,6 +31,7 @@
 	}
 	&__nav {
 		display: flex;
+		outline: revert;
 		align-items: center;
 		position: absolute;
 		text-decoration: none;
@@ -44,7 +45,6 @@
 
 		&:focus {
 			-webkit-tap-highlight-color: transparent;
-			outline: none;
 			-ms-touch-action: manipulation;
 			touch-action: manipulation;
 		}

--- a/src/scss/_generic.resets.scss
+++ b/src/scss/_generic.resets.scss
@@ -24,7 +24,6 @@
 	line-height: normal;
 	overflow: visible;
 	padding: 0;
-	outline: none;
 	&::-moz-focus-inner {
 		border: 0;
 		padding: 0;

--- a/src/scss/_utilities.display.scss
+++ b/src/scss/_utilities.display.scss
@@ -7,3 +7,14 @@
 		display: none !important;
 	}
 }
+
+.mc-picker-vhidden {
+	border: 0;
+    clip: rect(1px, 1px, 1px, 1px);
+    height: 1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    top: 0;
+    width: 1px;
+}


### PR DESCRIPTION
The first commit completes the original intention of my previous pull request #32 by correctly utilizing the `context` property across the whole project. It also adds a shadow dom example to `sandbox/` for proper testing.

The 2nd commit addresses accessibility concerns and adds/improves the following:

- Keyboard navigation
- Focus order
- Aria attributes